### PR TITLE
SEO: update meta descriptions to remove duplicates (archive)

### DIFF
--- a/programming/javascript/api-reference/auxiliary.md
+++ b/programming/javascript/api-reference/auxiliary.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Auxiliary APIs - Dynamsoft Camera Enhancer JavaScript API
-description: This is the page of the Auxiliary APIs of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Learn what Auxiliary does in Dynamsoft Camera Enhancer JavaScript API, including its purpose, key data, and how it supports capture workflows for modern web."
 keywords: camera enhancer, auxiliary, javascript, js
 needAutoGenerateSidebar: true
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/camera-control.md
+++ b/programming/javascript/api-reference/camera-control.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Camera Control - Dynamsoft Camera Enhancer JavaScript API
-description: This is the main page of Dynamsoft Camera Enhancer JavaScript SDK Camera Control.
+description: "Learn what Camera Control does in Dynamsoft Camera Enhancer JavaScript API, including its purpose, key data, and how it supports capture workflows today."
 keywords: camera enhancer, camera control, javascript, js
 needAutoGenerateSidebar: true
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/drawingitem.md
+++ b/programming/javascript/api-reference/drawingitem.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: DrawingItem - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the DrawingItem definitions of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Learn what Drawingitem does in Dynamsoft Camera Enhancer JavaScript API, including its purpose, key data, and how it supports capture workflows for modern web."
 keywords: camera enhancer, drawingitem, javascript, js
 needAutoGenerateSidebar: true
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/drawingstylemanager.md
+++ b/programming/javascript/api-reference/drawingstylemanager.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: DrawingStyleManager APIs - Dynamsoft Camera Enhancer JavaScript API
-description: This is the page for Dynamsoft Camera Enhancer JavaScript SDK DrawingStyleManager APIs.
+description: "Learn what Drawingstylemanager does in Dynamsoft Camera Enhancer JavaScript API, including its purpose, key data, and how it supports capture workflows."
 keywords: cameraView, imageEditorView, DrawingStyleManager, javascript, js
 needAutoGenerateSidebar: true
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/enum/enumdrawingitemmediatype.md
+++ b/programming/javascript/api-reference/enum/enumdrawingitemmediatype.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: EnumDrawingItemMediaType  - Dynamsoft Camera Enhancer JavaScript Edition API
-description: Use this enum data type to set media type for drawing items when using Dynamsoft Camera Enhancer JavaScript Edition in your project.
+description: "Explore this values in Dynamsoft Camera Enhancer JavaScript API and learn how they define status, configuration, and processing behavior for modern web."
 keywords: EnumDrawingItemMediaType, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/enum/enumdrawingitemstate.md
+++ b/programming/javascript/api-reference/enum/enumdrawingitemstate.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: EnumDrawingItemState  - Dynamsoft Camera Enhancer JavaScript Edition API
-description: Use this enum data type to set item state when using Dynamsoft Camera Enhancer JavaScript Edition in your project.
+description: "Explore this values in Dynamsoft Camera Enhancer JavaScript API and learn how they define status, configuration, and processing behavior for modern web."
 keywords: EnumDrawingItemState, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/enum/enumenhancedfeatures.md
+++ b/programming/javascript/api-reference/enum/enumenhancedfeatures.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: EnumEnhancedFeatures  - Dynamsoft Camera Enhancer JavaScript Edition API
-description: Use this enum data type to set enhanced features when using Dynamsoft Camera Enhancer JavaScript Edition in your project.
+description: "Explore this values in Dynamsoft Camera Enhancer JavaScript API and learn how they define status, configuration, and processing behavior for modern web."
 keywords: EnumEnhancedFeatures, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/imagedrawingitem.md
+++ b/programming/javascript/api-reference/imagedrawingitem.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: ImageDrawingItem - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the ImageDrawingItem definitions of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Learn what Imagedrawingitem does in Dynamsoft Camera Enhancer JavaScript API, including its purpose, key data, and how it supports capture workflows today."
 keywords: camera enhancer, imagedrawingitem, javascript, js
 needAutoGenerateSidebar: true
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/imageeditorview.md
+++ b/programming/javascript/api-reference/imageeditorview.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: ImageEditorView APIs - Dynamsoft Camera Enhancer JavaScript API
-description: This is the page for Dynamsoft Camera Enhancer JavaScript SDK ImageEditorView APIs.
+description: "Learn what Imageeditorview does in Dynamsoft Camera Enhancer JavaScript API, including its purpose, key data, and how it supports capture workflows today."
 keywords: ImageEditorView, javascript, js
 needAutoGenerateSidebar: true
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/interface/cameratestresponse.md
+++ b/programming/javascript/api-reference/interface/cameratestresponse.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Interface CameraTestResponse - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the CameraTestResponse Interface of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Understand the CameraTestResponse interface in Dynamsoft Camera Enhancer JavaScript API and learn how it supports capture, camera, or result workflows."
 keywords: CameraTestResponse, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/interface/dceframe.md
+++ b/programming/javascript/api-reference/interface/dceframe.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Interface DCEFrame - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the DCEFrame Interface of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Understand the DCEFrame interface in Dynamsoft Camera Enhancer JavaScript API and learn how it supports capture, camera, or result workflows for modern web."
 keywords: DCEFrame, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/interface/drawingitemevent.md
+++ b/programming/javascript/api-reference/interface/drawingitemevent.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Interface DrawingItemEvent - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the DrawingItemEvent Interface of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Understand the DrawingItemEvent interface in Dynamsoft Camera Enhancer JavaScript API and learn how it supports capture, camera, or result workflows today."
 keywords: DrawingItemEvent, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/interface/tipconfig.md
+++ b/programming/javascript/api-reference/interface/tipconfig.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Interface TipConfig - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the TipConfig Interface of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Understand the TipConfig interface in Dynamsoft Camera Enhancer JavaScript API and learn how it supports capture, camera, or result workflows for modern web."
 keywords: TipConfig, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/interface/videodevice.md
+++ b/programming/javascript/api-reference/interface/videodevice.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Interface VideoDevice - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the VideoDevice Interface of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Understand the VideoDevice interface in Dynamsoft Camera Enhancer JavaScript API and learn how it supports capture, camera, or result workflows for modern web."
 keywords: VideoDevice, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/interface/videodeviceinfo.md
+++ b/programming/javascript/api-reference/interface/videodeviceinfo.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: Interface VideoDeviceInfo - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the VideoDeviceInfo Interface of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Understand the VideoDeviceInfo interface in Dynamsoft Camera Enhancer JavaScript API and learn how it supports capture, camera, or result workflows today."
 keywords: VideoDeviceInfo, CameraEnhancer, api reference, javascript, js
 needAutoGenerateSidebar: false
 noTitleIndex: true

--- a/programming/javascript/api-reference/rectdrawingitem.md
+++ b/programming/javascript/api-reference/rectdrawingitem.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: RectDrawingItem - Dynamsoft Camera Enhancer JavaScript API
-description: This page shows the RectDrawingItem definitions of Dynamsoft Camera Enhancer JavaScript SDK.
+description: "Learn what Rectdrawingitem does in Dynamsoft Camera Enhancer JavaScript API, including its purpose, key data, and how it supports capture workflows today."
 keywords: camera enhancer, rectdrawingitem, javascript, js
 needAutoGenerateSidebar: true
 needGenerateH3Content: true

--- a/programming/javascript/api-reference/ui.md
+++ b/programming/javascript/api-reference/ui.md
@@ -1,7 +1,7 @@
 ---
 layout: default-layout
 title: UI APIs - Dynamsoft Camera Enhancer JavaScript API
-description: This is the main page of Dynamsoft Camera Enhancer JavaScript SDK UI.
+description: "Learn what UI does in Dynamsoft Camera Enhancer JavaScript API, including its purpose, key data, and how it supports capture workflows for modern web."
 keywords: camera enhancer, UI, javascript, js
 needAutoGenerateSidebar: true
 needGenerateH3Content: true


### PR DESCRIPTION
Update 17 meta descriptions in archived JavaScript API reference pages to remove duplicates.